### PR TITLE
fix: enhance length validation for different parameter types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .nyc_output
 coverage
 .vscode
+.idea
 .npmrc
 bench/node_modules/
 dist/

--- a/defaultMethods.js
+++ b/defaultMethods.js
@@ -153,7 +153,17 @@ const defaultMethods = {
     }
     return string.substr(from, end)
   },
-  length: (i) => i.length,
+  length: (i) => {
+    if ((typeof i === 'string' || Array.isArray(i))) {
+      return i.length
+    }
+
+    if (i && typeof i === 'object') {
+      return Object.keys(i).length
+    }
+
+    return 0
+  },
   get: {
     method: ([data, key, defaultValue], context, above, engine) => {
       const notFound = defaultValue === undefined ? null : defaultValue


### PR DESCRIPTION
I noticed that the logic crashes when I want to check the length of a value that may be null in some cases, I made a fix for that - maybe someone will find it useful.