### PR TITLE
export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./index.d.ts"
     }
   },
   "types": "./index.d.ts",


### PR DESCRIPTION
This fixes missing type errors when respecting the `exports` section of the package.json