### PR TITLE
Resolve dynamic key issue with compiled "get" #21

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -317,7 +317,7 @@ function buildString (method, buildState = {}) {
         `gen["${func}"](` + buildString(method[func], buildState) + ')'
       )
     } else {
-      if (engine.methods[func] && engine.methods[func].traverse) {
+      if (engine.methods[func] && (typeof engine.methods[func].traverse === 'undefined' ? true : engine.methods[func].traverse)) {
         functions[func] = 1
         asyncDetected = Boolean(
           async && engine.methods[func] && engine.methods[func].asyncMethod

--- a/defaultMethods.js
+++ b/defaultMethods.js
@@ -805,6 +805,10 @@ defaultMethods.get.compile = function (data, buildState) {
     obj = data[0]
     key = data[1]
     defaultValue = typeof data[2] === 'undefined' ? null : data[2]
+
+    // Bail out if the key is dynamic; dynamic keys are not really optimized by this block.
+    if (key && typeof key === 'object') return false
+
     key = key.toString()
     const pieces = key.split('.')
     if (!chainingSupported) {
@@ -813,11 +817,11 @@ defaultMethods.get.compile = function (data, buildState) {
           return `(${text}||0)[${JSON.stringify(i)}]`
         },
         `(${buildString(obj, buildState)}||0)`
-      )}, ${JSON.stringify(defaultValue)}))`
+      )}, ${buildString(defaultValue, buildState)}))`
     }
     return `((${buildString(obj, buildState)})${pieces
-      .map((i) => `?.[${JSON.stringify(i)}]`)
-      .join('')} ?? ${JSON.stringify(defaultValue)})`
+      .map((i) => `?.[${buildString(i, buildState)}]`)
+      .join('')} ?? ${buildString(defaultValue, buildState)})`
   }
   return false
 }
@@ -860,11 +864,11 @@ defaultMethods.var.compile = function (data, buildState) {
           return `(${text}||0)[${JSON.stringify(i)}]`
         },
         '(context||0)'
-      )}, ${JSON.stringify(defaultValue)}))`
+      )}, ${buildString(defaultValue, buildState)}))`
     }
     return `(context${pieces
       .map((i) => `?.[${JSON.stringify(i)}]`)
-      .join('')} ?? ${JSON.stringify(defaultValue)})`
+      .join('')} ?? ${buildString(defaultValue, buildState)})`
   }
   buildState.useContext = true
   return false

--- a/general.test.js
+++ b/general.test.js
@@ -105,4 +105,16 @@ describe('Various Test Cases', () => {
       }, obj, 'equal')
     }
   })
+
+  it('get operator w/ object key as string', async () => {
+    for (const engine of [...normalEngines, ...permissiveEngines]) await testEngine(engine, { get: [{ var: 'selected' }, 'b'] }, { selected: { b: 2 } }, 2)
+  })
+
+  it('get operator w/ object key as number', async () => {
+    for (const engine of [...normalEngines, ...permissiveEngines]) await testEngine(engine, { get: [{ var: 'selected' }, 1] }, { selected: [0, 2] }, 2)
+  })
+
+  it('get operator w/ object key as var', async () => {
+    for (const engine of [...normalEngines, ...permissiveEngines]) await testEngine(engine, { get: [{ var: 'selected' }, { var: 'key' }] }, { selected: { b: 2 }, key: 'b' }, 2)
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-logic-engine",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Construct complex rules with JSON & process them.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
This MR resolves an issue with the `get` method in compiled mode that prevents it from using dynamic keys as intended.