### PR TITLE
Improve Permissive Implementation; Allows Data Detection Override

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -62,6 +62,9 @@ function isDeterministic (method, engine, buildState) {
     const func = Object.keys(method)[0]
     const lower = method[func]
 
+    if (engine.isData(method, func)) return true
+    if (!engine.methods[func]) throw new Error(`Method '${func}' was not found in the Logic Engine.`)
+
     if (engine.methods[func].traverse === false) {
       return typeof engine.methods[func].deterministic === 'function'
         ? engine.methods[func].deterministic(lower, buildState)
@@ -274,8 +277,8 @@ function buildString (method, buildState = {}) {
   if (method && typeof method === 'object') {
     if (!func) return pushValue(method)
     if (!engine.methods[func]) {
-      // If we are in permissive mode, we will just return the object.
-      if (engine.options.permissive) return pushValue(method, true)
+      // Check if this is supposed to be "data" rather than a function.
+      if (engine.isData(method, func)) return pushValue(method, true)
       throw new Error(`Method '${func}' was not found in the Logic Engine.`)
     }
     functions[func] = functions[func] || 2

--- a/customEngines.test.js
+++ b/customEngines.test.js
@@ -1,0 +1,45 @@
+
+import { LogicEngine, AsyncLogicEngine } from './index.js'
+
+class DataEngine extends LogicEngine {
+  isData (logic, firstKey) {
+    if (Object.keys(logic).length > 1) return true
+    return !(firstKey in logic)
+  }
+}
+
+class AsyncDataEngine extends AsyncLogicEngine {
+  isData (logic, firstKey) {
+    if (Object.keys(logic).length > 1) return true
+    return !(firstKey in logic)
+  }
+}
+
+const engine = new DataEngine()
+const asyncEngine = new AsyncDataEngine()
+
+describe('Custom Engines (isData)', () => {
+  const logic = {
+    get: [{
+      xs: 10,
+      s: 20,
+      m: 30
+    }, {
+      var: 'size'
+    }]
+  }
+
+  const data = {
+    size: 's'
+  }
+
+  it('Should let us override how data is detected (sync)', () => {
+    const f = engine.build(logic)
+    expect(f(data)).toEqual(20)
+  })
+
+  it('Should let us override how data is detected (async)', async () => {
+    const f = await asyncEngine.build(logic)
+    expect(await f(data)).toEqual(20)
+  })
+})

--- a/customEngines.test.js
+++ b/customEngines.test.js
@@ -4,14 +4,14 @@ import { LogicEngine, AsyncLogicEngine } from './index.js'
 class DataEngine extends LogicEngine {
   isData (logic, firstKey) {
     if (Object.keys(logic).length > 1) return true
-    return !(firstKey in logic)
+    return !(firstKey in this.methods)
   }
 }
 
 class AsyncDataEngine extends AsyncLogicEngine {
   isData (logic, firstKey) {
     if (Object.keys(logic).length > 1) return true
-    return !(firstKey in logic)
+    return !(firstKey in this.methods)
   }
 }
 

--- a/defaultMethods.js
+++ b/defaultMethods.js
@@ -18,7 +18,8 @@ function isDeterministic (method, engine, buildState) {
     const func = Object.keys(method)[0]
     const lower = method[func]
 
-    if (!engine.methods[func] && engine.options.permissive) return true
+    if (engine.isData(method, func)) return true
+    if (!engine.methods[func]) throw new Error(`Method '${func}' was not found in the Logic Engine.`)
 
     if (engine.methods[func].traverse === false) {
       return typeof engine.methods[func].deterministic === 'function'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-logic-engine",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Construct complex rules with JSON & process them.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION

Based on the discussion in #28, I decided to improve how the Permissive implementation is handled to allow users to better customize how the data detection is implemented.

I do realize that as I add these capabilities, we might be making it slightly more difficult to maintain a fully compatible cross-language json-logic ecosystem, however, I'm comfortable supporting some of these extensions as long as it is clear to folks that these behaviors might not translate to other libraries by other authors. 

Anyway:

I've changed the engine implementation to allow a user to specify how "data" is detected in one's logic. 

```javascript 
class DataEngine extends LogicEngine {
  isData (logic, firstKey) {
    if (Object.keys(logic).length > 1) return true
    return !(firstKey in this.methods)
  }
}
```

You can extend logic engine and implement an `isData` method to specify if an object embedded in the logic should be treated as data, rather than treating it as a command. 

This should give developers full flexibility in how they believe this should work, as there will be different opinions:
- "Could it work via attaching a symbol to the object?"
- "Could it treat it as data if it has more than 1 key?"
- "Could it treat it as data if the function isn't recognized?"

Etc.