### PR TITLE
fix: 'keys' method now returns empty array for non-object inputs

### DIFF
--- a/async.test.js
+++ b/async.test.js
@@ -626,6 +626,12 @@ modes.forEach((logic) => {
         }
       })
       expect(answer).toStrictEqual(['a', 'b'])
+
+      const answer2 = await logic.run({
+        keys: 'foo'
+      })
+
+      expect(answer2).toStrictEqual([])
     })
 
     test('substr', async () => {

--- a/defaultMethods.js
+++ b/defaultMethods.js
@@ -369,7 +369,7 @@ const defaultMethods = {
   '!': (value) => Array.isArray(value) ? !value[0] : !value,
   '!!': (value) => Boolean(Array.isArray(value) ? value[0] : value),
   cat: (arr) => (typeof arr === 'string' ? arr : arr.join('')),
-  keys: (obj) => Object.keys(obj),
+  keys: (obj) => typeof obj === 'object' ? Object.keys(obj) : [],
   eachKey: {
     traverse: false,
     method: (object, context, above, engine) => {

--- a/test.js
+++ b/test.js
@@ -652,6 +652,12 @@ modes.forEach((logic) => {
       })
 
       expect(answer).toStrictEqual(['a', 'b'])
+
+      const answer2 = logic.run({
+        keys: 'foo'
+      })
+
+      expect(answer2).toStrictEqual([])
     })
 
     test('substr', () => {


### PR DESCRIPTION
when we use something other than an object for the keys method, we get an error

if possible please merge and release a new version 😄 