### PR TITLE
Fix function check in var method

### DIFF
--- a/async.test.js
+++ b/async.test.js
@@ -826,6 +826,17 @@ modes.forEach((logic) => {
       ).toBe(null)
     })
 
+    test('allow access to objects named as their methods', async () => {
+      expect(
+        await logic.run(
+          {
+            var: 'toString'
+          },
+          {toString: 'hello'}
+        )
+      ).toBe("hello")
+    })
+
     test('allow access to functions on objects when enabled', async () => {
       logic.allowFunctions = true
       expect(

--- a/defaultMethods.js
+++ b/defaultMethods.js
@@ -217,7 +217,7 @@ const defaultMethods = {
         return notFound
       }
     }
-    if (engine.allowFunctions || typeof (context && context[key]) !== 'function') {
+    if (engine.allowFunctions || typeof context !== 'function') {
       return context
     }
     return null


### PR DESCRIPTION
Rules like:

```
logic.run({var: 'toString'},{toString: 'hello'}) // expect "hello"
logic.run({var: 'values'},{values: [1,2,3]}) // expect [1,2,3]

```

return null because "hello".toString is a function, even if we want to get "hello" (a valid object, not a function)

This happens because we're checking for `context[key]` even when `key` is already implied in context because we have descended into it during the previous for loop.