### PR TITLE
Add caching for optional chaining support check

### DIFF
--- a/utilities/chainingSupported.js
+++ b/utilities/chainingSupported.js
@@ -15,7 +15,7 @@ const getIsOptionalChainingSupported = () => {
     const isUndefined = (typeof globalThis !== 'undefined' ? globalThis : global).eval('(test) => test?.foo?.bar')(test)
     return result = (isUndefined === undefined)
   } catch (err) {
-    return false
+    return result = false
   }
 }
 export default getIsOptionalChainingSupported()


### PR DESCRIPTION
Caches the result of the environment support for optional chaining to avoid having to execute the try/catch repeatedly.